### PR TITLE
Address MSVC C4267 warnings

### DIFF
--- a/gzread.c
+++ b/gzread.c
@@ -316,7 +316,7 @@ local z_size_t gz_read(state, buf, len)
         /* set n to the maximum amount of len that fits in an unsigned int */
         n = -1;
         if (n > len)
-            n = len;
+            n = (unsigned)len;
 
         /* first just try copying data from the output buffer */
         if (state->x.have) {
@@ -396,8 +396,8 @@ int ZEXPORT gzread(file, buf, len)
         return -1;
     }
 
-    /* read len or fewer bytes to buf */
-    len = gz_read(state, buf, len);
+    /* read len or fewer bytes to buf (this is assured to fit in an int) */
+    len = (int)gz_read(state, buf, len);
 
     /* check for an error */
     if (len == 0 && state->err != Z_OK && state->err != Z_BUF_ERROR)
@@ -469,7 +469,7 @@ int ZEXPORT gzgetc(file)
     }
 
     /* nothing there -- try gz_read() */
-    ret = gz_read(state, buf, 1);
+    ret = (int)gz_read(state, buf, 1);
     return ret < 1 ? -1 : buf[0];
 }
 

--- a/gzwrite.c
+++ b/gzwrite.c
@@ -209,7 +209,7 @@ local z_size_t gz_write(state, buf, len)
                               state->in);
             copy = state->size - have;
             if (copy > len)
-                copy = len;
+                copy = (unsigned)len;
             memcpy(state->in + have, buf, copy);
             state->strm.avail_in += copy;
             state->x.pos += copy;
@@ -229,7 +229,7 @@ local z_size_t gz_write(state, buf, len)
         do {
             unsigned n = (unsigned)-1;
             if (n > len)
-                n = len;
+                n = (unsigned)len;
             state->strm.avail_in = n;
             state->x.pos += n;
             if (gz_comp(state, Z_NO_FLUSH) == -1)
@@ -368,7 +368,12 @@ int ZEXPORT gzputs(file, str)
 
     /* write string */
     len = strlen(str);
-    ret = gz_write(state, str, len);
+    if ((int)len < 0) {
+        gz_error(state, Z_STREAM_ERROR, "strlen does not fit in an int");
+        return -1;
+    }
+
+    ret = (int)gz_write(state, str, len);
     return ret == 0 && len != 0 ? -1 : ret;
 }
 


### PR DESCRIPTION
Mostly, the warnings were false positives and were silenced using typecasting.

However, gzputs() did allow integer overflow when input string is longer than 2 Gi characters.