### PR TITLE
Fix Cmake Configuration Errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -225,25 +225,3 @@ endif()
 if(NOT SKIP_INSTALL_FILES AND NOT SKIP_INSTALL_ALL )
     install(FILES ${ZLIB_PC} DESTINATION "${INSTALL_PKGCONFIG_DIR}")
 endif()
-
-#============================================================================
-# Example binaries
-#============================================================================
-
-add_executable(example test/example.c)
-target_link_libraries(example zlib)
-add_test(example example)
-
-add_executable(minigzip test/minigzip.c)
-target_link_libraries(minigzip zlib)
-
-if(HAVE_OFF64_T)
-    add_executable(example64 test/example.c)
-    target_link_libraries(example64 zlib)
-    set_target_properties(example64 PROPERTIES COMPILE_FLAGS "-D_FILE_OFFSET_BITS=64")
-    add_test(example64 example64)
-
-    add_executable(minigzip64 test/minigzip.c)
-    target_link_libraries(minigzip64 zlib)
-    set_target_properties(minigzip64 PROPERTIES COMPILE_FLAGS "-D_FILE_OFFSET_BITS=64")
-endif()

--- a/zconf.h.cmakein
+++ b/zconf.h.cmakein
@@ -10,6 +10,15 @@
 #cmakedefine Z_PREFIX
 #cmakedefine Z_HAVE_UNISTD_H
 
+
+#ifdef __APPLE__
+/* use wxWidgets' configure */
+#include "wx/setup.h"
+#endif
+
+/* wxWidgets always uses custom prefix to avoid conflicts. */
+#define Z_PREFIX_ wx_zlib_
+
 /*
  * Defining custom Z_PREFIX_ implies using Z_PREFIX.
  */

--- a/zconf.h.in
+++ b/zconf.h.in
@@ -8,6 +8,15 @@
 #ifndef ZCONF_H
 #define ZCONF_H
 
+
+#ifdef __APPLE__
+/* use wxWidgets' configure */
+#include "wx/setup.h"
+#endif
+
+/* wxWidgets always uses custom prefix to avoid conflicts. */
+#define Z_PREFIX_ wx_zlib_
+
 /*
  * Defining custom Z_PREFIX_ implies using Z_PREFIX.
  */


### PR DESCRIPTION
The WxWidgets fork of zlib has two configuration errors.
The root cmakelists.txt references files that have been deleted in this fork used for tests and examples.
The zconf.h used in the build is generated from the zconf.cmake.in file and copied to the build folder. The fork only modified the zconf.h file in the root directory that is unused.